### PR TITLE
fixed URL composition

### DIFF
--- a/redmine/redmine_rest.py
+++ b/redmine/redmine_rest.py
@@ -652,7 +652,7 @@ class Redmine_WS(object):
             urldata = '?' + urllib.urlencode( parms )
         
         
-        fullUrl = self._url + '/' + page
+        fullUrl = self._url + page
         
         # register this url to be used with the opener
         # must be registered for each unique path


### PR DESCRIPTION
The paths in the containers are already given with a preceding `/`, and
the introduction of an extra `/` in the fullURL composition gives an URL
with a double `//` which redmine cannot handle.
