### PR TITLE
Correct dateutil dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -486,7 +486,7 @@ Not every item supports every method.  For instance, no current version of Redmi
 setup(
     name = "pyredmine",
     packages = ["redmine"],
-    install_requires = ["dateutil"],
+    install_requires = ["python-dateutil"],
     version = "0.2.4",
     description = "Python Redmine Web Services Library",
     long_description = readme(),


### PR DESCRIPTION
I find this necessary with Python2.7 in a Windows environment.

Looking further at https://pypi.python.org/pypi/python-dateutil, it appears `python-dateutil` is actually the correct package name.  Perhaps it was recently renamed?
