### PR TITLE
Direct access to HTTP request within .get() method

### DIFF
--- a/redmine/redmine.py
+++ b/redmine/redmine.py
@@ -183,6 +183,25 @@ class Issue(Redmine_Item):
 		self.time_entries._query_path = '/issues/%s/time_entries.json' % self.id
 		self.time_entries._item_new_path = self.time_entries._query_path
 
+
+        @property
+        def journals(self):
+                """
+                Retrieve journals attribute for this Issue
+                """
+                try:
+                    target = self._item_path
+                    json_data = self._redmine.get(target % str(self.id), parms = {'include': 'journals'})
+                    data = self._redmine.unwrap_json(None, json_data)
+                    journals = [ Journal(redmine=self._redmine, data=j, type='issue_journal')
+                                 for j in data['issue']['journals']]
+
+                    return journals
+
+                except:
+                    return []
+
+
 	def __str__(self):
 		return '<Redmine issue #%s, "%s">' % (self.id, self.subject)
 
@@ -214,6 +233,33 @@ class Issue(Redmine_Item):
 		'''Save all changes and close this issue'''
 		self.set_status( self._redmine.ISSUE_STATUS_ID_CLOSED, notes=notes )
 
+class Journal(Redmine_Item):
+        """
+        Objetc for representing a single Redmine issue journal entry.
+        """
+        # u'notes': u'test', u'created_on': u'2013-06-08T21:54:40Z', u'user': {u'name': u'R\xe9mi Ferrand', u'id': 68}, u'details': [], u'id': 10602}
+        # data hints:
+        notes = None
+        created_on = None
+        user = None
+        details = None
+        id = None
+
+        _protected_attr = ['id', 'created_on','user']
+
+        _field_type = {
+            'created_on': 'datetime',
+            'user'      : 'user'
+        }
+
+	# How to communicate this info to/from the server
+	_query_container = 'journals'
+	_query_path = ''
+	_item_path = ''
+	_item_new_path = ''
+
+	def __str__(self):
+		return '<Redmine issue_journal #%s>' % (self.id)
 
 
 class User(Redmine_Item):

--- a/redmine/redmine_rest.py
+++ b/redmine/redmine_rest.py
@@ -176,7 +176,10 @@ class Redmine_Item(object):
 
             try:
                 # Try and remap to the required dictionary
-                self._changes['custom_field_values'] = { f['id']:f.get('value','') for f in self._changes['custom_fields']}
+                t = {}
+                for f in self._changes['custom_fields']:
+                    t[f['id']] = f.get('value', '')
+                self._changes['custom_field_values'] = t
             except:
                 pass
             else:
@@ -319,11 +322,16 @@ class Custom_Fields(object):
     
     def _get_all(self):
         '''Return all values.'''
-        return { f['id']:f.get('value','') for f in self._data }
+        t = {}
+        for f in self._data:
+            t[f['id']] = f.get('value', '')
+        return t
 
     def _get_changes(self):
         '''Get all changed values.'''
-        result = { f['id']:f.get('value','') for f in self._data if f.get('changed', False)}
+        result = {}
+        for f in [a for a in self._data if f.get('changed', False)]:
+            result[f['id']] = f.get('value', '')
         self._clear_changes
         return result
         

--- a/redmine/redmine_rest.py
+++ b/redmine/redmine_rest.py
@@ -532,12 +532,12 @@ class Redmine_Items_Manager(object):
         data['_source_path'] = target
         return self._objectify(data=data)
     
-    def get(self, id):
+    def get(self, id, **options):
         '''Get a single item with the given ID'''
         if not self._item_path:
             raise AttributeError('get is not available for %s' % self._item_name)
         target = self._item_path % id
-        json_data = self._redmine.get(target)
+        json_data = self._redmine.get(target, **options)
         data = self._redmine.unwrap_json(self._item_type, json_data)
         data['_source_path'] = target
         return self._objectify(data=data)


### PR DESCRIPTION
In order to create some queries like "GET /issues/296.xml?include=journals" I added an extra keyword arg to Redmine_Items_Manager.get() method in that's directly passed to the lower .get() method.

That way I can query "journals" or any other attribute of a particular issue.
If there was another way to accomplish this I wasn't able to figure it out :-)

Thanks again for your work, your module is really great to work with !

R.
